### PR TITLE
Dapr Secrets

### DIFF
--- a/src/DaprExtension/Bindings/DaprPubSubEvent.cs
+++ b/src/DaprExtension/Bindings/DaprPubSubEvent.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
         /// Gets the name of the topic.
         /// </summary>
         /// <remarks>
-        /// If the topic name is not specified, it is inferred from the 
+        /// If the topic name is not specified, it is inferred from the
         /// <see cref="DaprPublishAttribute"/> binding attribute.
         /// </remarks>
         [JsonProperty("topic")]

--- a/src/DaprExtension/Bindings/DaprSecretAttribute.cs
+++ b/src/DaprExtension/Bindings/DaprSecretAttribute.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.Dapr
+{
+    using System;
+    using Microsoft.Azure.WebJobs.Description;
+
+    /// <summary>
+    /// Parameter attribute for the Dapr secret input binding.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    [Binding]
+    public sealed class DaprSecretAttribute : DaprBaseAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DaprSecretAttribute"/> class.
+        /// </summary>
+        /// <param name="secretStoreName">The name of the secret store to get the secret from.</param>
+        /// <param name="key">The key identifying the name of the secret to get.</param>
+        public DaprSecretAttribute(string secretStoreName, string key)
+        {
+            this.SecretStoreName = secretStoreName ?? throw new ArgumentNullException(nameof(secretStoreName));
+            this.Key = key ?? throw new ArgumentNullException(nameof(key));
+        }
+
+        /// <summary>
+        /// Gets the name of the secret store to get the secret from.
+        /// </summary>
+        [AutoResolve]
+        public string SecretStoreName { get; private set; }
+
+        /// <summary>
+        /// Gets the key identifying the name of the secret to get.
+        /// </summary>
+        [AutoResolve]
+        public string? Key { get; private set; }
+
+        /// <summary>
+        /// Gets or sets an array of metadata properties in the form "key1=value1&amp;key2=value2".
+        /// </summary>
+        [AutoResolve]
+        public string? Metadata { get; set; }
+    }
+}

--- a/src/DaprExtension/Bindings/DaprSecretConverter.cs
+++ b/src/DaprExtension/Bindings/DaprSecretConverter.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Extensions.Dapr
+{
+    using System;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.WebJobs;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    class DaprSecretConverter :
+        IAsyncConverter<DaprSecretAttribute, JObject>,
+        IAsyncConverter<DaprSecretAttribute, string?>,
+        IAsyncConverter<DaprSecretAttribute, byte[]>
+    {
+        readonly DaprServiceClient daprClient;
+
+        public DaprSecretConverter(DaprServiceClient daprClient)
+        {
+            this.daprClient = daprClient;
+        }
+
+        Task<JObject> IAsyncConverter<DaprSecretAttribute, JObject>.ConvertAsync(
+            DaprSecretAttribute input,
+            CancellationToken cancellationToken)
+        {
+            return this.GetSecretsAsync(input, cancellationToken);
+        }
+
+        async Task<string?> IAsyncConverter<DaprSecretAttribute, string?>.ConvertAsync(
+            DaprSecretAttribute input,
+            CancellationToken cancellationToken)
+        {
+            JObject result = await this.GetSecretsAsync(input, cancellationToken);
+            return result.PropertyValues().FirstOrDefault()?.ToString();
+        }
+
+        async Task<byte[]> IAsyncConverter<DaprSecretAttribute, byte[]>.ConvertAsync(
+            DaprSecretAttribute input,
+            CancellationToken cancellationToken)
+        {
+            // Just return the first value in the object.
+            JObject result = await this.GetSecretsAsync(input, cancellationToken);
+            JToken jsonData = result.PropertyValues().FirstOrDefault();
+            if (jsonData == null)
+            {
+                return Array.Empty<byte>();
+            }
+
+            if (jsonData.Type == JTokenType.Bytes)
+            {
+                return (byte[])jsonData;
+            }
+            else if (jsonData.Type == JTokenType.String)
+            {
+                return Encoding.UTF8.GetBytes((string)jsonData);
+            }
+
+            return Encoding.UTF8.GetBytes(jsonData.ToString(Formatting.None));
+        }
+
+        Task<JObject> GetSecretsAsync(DaprSecretAttribute input, CancellationToken cancellationToken)
+        {
+            return this.daprClient.GetSecretAsync(
+                input.DaprAddress,
+                input.SecretStoreName,
+                input.Key,
+                input.Metadata,
+                cancellationToken);
+        }
+    }
+}

--- a/src/DaprExtension/Bindings/DaprStateConverter.cs
+++ b/src/DaprExtension/Bindings/DaprStateConverter.cs
@@ -21,11 +21,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
         IAsyncConverter<DaprStateAttribute, JObject>,
         IAsyncConverter<DaprStateAttribute, object?>
     {
-        readonly DaprServiceClient daprService;
+        readonly DaprServiceClient daprClient;
 
-        public DaprStateConverter(DaprServiceClient daprService)
+        public DaprStateConverter(DaprServiceClient daprClient)
         {
-            this.daprService = daprService;
+            this.daprClient = daprClient;
         }
 
         public async Task<byte[]> ConvertAsync(DaprStateAttribute input, CancellationToken cancellationToken)
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
 
         async Task<DaprStateRecord> GetStateRecordAsync(DaprStateAttribute input, CancellationToken cancellationToken)
         {
-            DaprStateRecord stateRecord = await this.daprService.GetStateAsync(
+            DaprStateRecord stateRecord = await this.daprClient.GetStateAsync(
                 input.DaprAddress,
                 input.StateStore ?? throw new ArgumentException("No state store name was specified.", nameof(input.StateStore)),
                 input.Key ?? throw new ArgumentException("No state store key was specified.", nameof(input.Key)),

--- a/src/DaprExtension/DaprExtensionConfigProvider.cs
+++ b/src/DaprExtension/DaprExtensionConfigProvider.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
 
             var daprStateConverter = new DaprStateConverter(this.daprClient);
 
+            // NOTE: The order of conversions for each binding rules is important!
             var stateRule = context.AddBindingRule<DaprStateAttribute>();
             stateRule.AddConverter<JObject, DaprStateRecord>(CreateSaveStateParameters);
             stateRule.AddConverter<object, DaprStateRecord>(CreateSaveStateParameters);
@@ -71,6 +72,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Dapr
             publishRule.AddConverter<JObject, DaprPubSubEvent>(CreatePubSubEvent);
             publishRule.AddConverter<object, DaprPubSubEvent>(CreatePubSubEvent);
             publishRule.BindToCollector(attr => new DaprPublishAsyncCollector(attr, this.daprClient));
+
+            var daprSecretConverter = new DaprSecretConverter(this.daprClient);
+            var secretsRule = context.AddBindingRule<DaprSecretAttribute>();
+            secretsRule.BindToInput<JObject>(daprSecretConverter);
+            secretsRule.BindToInput<string?>(daprSecretConverter);
+            secretsRule.BindToInput<byte[]>(daprSecretConverter);
 
             context.AddBindingRule<DaprMethodTriggerAttribute>()
                 .BindToTrigger(new DaprMethodTriggerBindingProvider(this.daprListener));

--- a/test/DaprExtensionTests/SavedHttpRequest.cs
+++ b/test/DaprExtensionTests/SavedHttpRequest.cs
@@ -11,6 +11,7 @@ namespace DaprExtensionTests
         {
             this.Method = request.Method;
             this.Path = request.Path;
+            this.Query = request.QueryString;
             this.ContentType = request.ContentType;
             this.ContentAsString = content;
         }
@@ -18,6 +19,8 @@ namespace DaprExtensionTests
         public string Method { get; }
 
         public PathString Path { get; }
+
+        public QueryString Query { get; }
 
         public string ContentType { get; }
 

--- a/test/DaprExtensionTests/Tests/DaprSecretBindingTests.cs
+++ b/test/DaprExtensionTests/Tests/DaprSecretBindingTests.cs
@@ -1,0 +1,168 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace DaprExtensionTests.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Azure.WebJobs.Extensions.Dapr;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class DaprSecretBindingTests : DaprTestBase
+    {
+        public DaprSecretBindingTests(ITestOutputHelper output)
+            : base(output)
+        {
+            this.AddFunctions(typeof(Functions));
+        }
+
+        [Fact]
+        public async Task GetSecret_ExplicitSettings_Metadata()
+        {
+            await this.CallFunctionAsync(nameof(Functions.GetSecret_ExplicitSettings_Metadata));
+
+            SavedHttpRequest req = this.GetSingleGetSecretRequest();
+            Assert.Equal("/v1.0/secrets/store1/key1", req.Path);
+            Assert.Equal("?metadata.version_id=1&metadata.version_stage=2", req.Query.ToString());
+
+            IEnumerable<string> functionLogs = this.GetFunctionLogs(nameof(Functions.GetSecret_ExplicitSettings_Metadata));
+            Assert.Contains("secret!", functionLogs);
+        }
+
+        [Fact]
+        public async Task GetSecret_ExplicitSettings_NoMetadata()
+        {
+            await this.CallFunctionAsync(nameof(Functions.GetSecret_ExplicitSettings_NoMetadata));
+
+            SavedHttpRequest req = this.GetSingleGetSecretRequest();
+            Assert.Equal("/v1.0/secrets/store1/key1", req.Path);
+            Assert.Equal(QueryString.Empty, req.Query);
+
+            IEnumerable<string> functionLogs = this.GetFunctionLogs(nameof(Functions.GetSecret_ExplicitSettings_NoMetadata));
+            Assert.Contains("secret!", functionLogs);
+        }
+
+        [Fact]
+        public async Task GetSecret_BindToSecretStoreName()
+        {
+            string storeName = "store1";
+            await this.CallFunctionAsync(nameof(Functions.GetSecret_BindToSecretStoreName), "store", storeName);
+
+            SavedHttpRequest req = this.GetSingleGetSecretRequest();
+            Assert.Equal($"/v1.0/secrets/{storeName}/key1", req.Path);
+            Assert.Equal(QueryString.Empty, req.Query);
+
+            IEnumerable<string> functionLogs = this.GetFunctionLogs(nameof(Functions.GetSecret_BindToSecretStoreName));
+            Assert.Contains("secret!", functionLogs);
+        }
+
+        [Fact]
+        public async Task GetSecret_BindToKeyName()
+        {
+            string keyName = "key1";
+            await this.CallFunctionAsync(nameof(Functions.GetSecret_BindToKeyName), "key", keyName);
+
+            SavedHttpRequest req = this.GetSingleGetSecretRequest();
+            Assert.Equal($"/v1.0/secrets/store1/{keyName}", req.Path);
+            Assert.Equal(QueryString.Empty, req.Query);
+
+            IEnumerable<string> functionLogs = this.GetFunctionLogs(nameof(Functions.GetSecret_BindToKeyName));
+            Assert.Contains("secret!", functionLogs);
+        }
+
+        [Fact]
+        public async Task GetSecret_BindToMetadata()
+        {
+            JObject metadata = JObject.FromObject(
+                new
+                {
+                    version_id = 3,
+                    version_stage = 4,
+                });
+            await this.CallFunctionAsync(nameof(Functions.GetSecret_BindToMetadata), "metadata", metadata);
+
+            SavedHttpRequest req = this.GetSingleGetSecretRequest();
+            Assert.Equal("/v1.0/secrets/store1/key1", req.Path);
+            Assert.Equal("?metadata.version_id=3&metadata.version_stage=4", req.Query.ToString());
+
+            IEnumerable<string> functionLogs = this.GetFunctionLogs(nameof(Functions.GetSecret_BindToMetadata));
+            Assert.Contains("secret!", functionLogs);
+        }
+
+        [Fact]
+        public async Task GetSecret_BindToJObject()
+        {
+            await this.CallFunctionAsync(nameof(Functions.GetSecret_BindToJObject));
+
+            SavedHttpRequest req = this.GetSingleGetSecretRequest();
+            Assert.Equal("/v1.0/secrets/store1/key1", req.Path);
+            Assert.Equal(QueryString.Empty, req.Query);
+
+            IEnumerable<string> functionLogs = this.GetFunctionLogs(nameof(Functions.GetSecret_BindToJObject));
+            Assert.Contains(@"{""key1"":""secret!""}", functionLogs);
+        }
+
+        [Fact]
+        public async Task GetSecret_BindToByteArray()
+        {
+            await this.CallFunctionAsync(nameof(Functions.GetSecret_BindToByteArray));
+
+            SavedHttpRequest req = this.GetSingleGetSecretRequest();
+            Assert.Equal("/v1.0/secrets/store1/key1", req.Path);
+            Assert.Equal(QueryString.Empty, req.Query);
+
+            IEnumerable<string> functionLogs = this.GetFunctionLogs(nameof(Functions.GetSecret_BindToByteArray));
+            Assert.Contains("secret!", functionLogs);
+        }
+
+        SavedHttpRequest GetSingleGetSecretRequest()
+        {
+            SavedHttpRequest[] requests = this.GetDaprRequests();
+            SavedHttpRequest req = Assert.Single(requests);
+            Assert.Equal("GET", req.Method);
+            return req;
+        }
+
+        // WARNING: In spite of what these test functions are doing, it's never a good idea to log secrets.
+        static class Functions
+        {
+            public static void GetSecret_ExplicitSettings_Metadata(
+                [DaprSecret("store1", "key1", Metadata = "metadata.version_id=1&metadata.version_stage=2")] string secret,
+                ILogger log) => log.LogInformation(secret);
+
+            public static void GetSecret_ExplicitSettings_NoMetadata(
+                [DaprSecret("store1", "key1")] string secret,
+                ILogger log) => log.LogInformation(secret);
+
+            public static void GetSecret_BindToSecretStoreName(
+                string store,
+                [DaprSecret("{store}", "key1")] string secret,
+                ILogger log) => log.LogInformation(secret);
+
+            public static void GetSecret_BindToKeyName(
+                string key,
+                [DaprSecret("store1", "{key}")] string secret,
+                ILogger log) => log.LogInformation(secret);
+
+            public static void GetSecret_BindToMetadata(
+                JObject metadata,
+                [DaprSecret("store1", "key1", Metadata = "metadata.version_id={metadata.version_id}&metadata.version_stage={metadata.version_stage}")] string secret,
+                ILogger log) => log.LogInformation(secret);
+
+            public static void GetSecret_BindToJObject(
+                [DaprSecret("store1", "key1")] JObject secret,
+                ILogger log) => log.LogInformation(secret.ToString(Formatting.None));
+
+            public static void GetSecret_BindToByteArray(
+                [DaprSecret("store1", "key1")] byte[] secret,
+                ILogger log) => log.LogInformation(Encoding.UTF8.GetString(secret));
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a `[DaprSecret]` input binding and associated tests. It adheres to the [Dapr Secrets API spec](https://github.com/dapr/docs/blob/master/reference/api/secrets_api.md).

There is also a test fix that fixes the currently broken CI.